### PR TITLE
Move example invoice from InvoiceEditor to seeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Invoice
 
-This is an example Redwood app, implementing a very minimal todo application.
+This is an example Redwood app, implementing a very minimal invoice application.
 Features you can see in action here:
 
 - Redwood Cells (see TodoListCell.js).

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ this in the root directory:
 yarn
 ```
 
-Set up the database and generate the database client:
+Set up the database, generate the database client, and populate the database
+with example invoice:
 
 ```terminal
 yarn redwood db up
-yarn redwood db generate
+yarn redwood db seed
 ```
 
 ### Fire it up

--- a/api/prisma/seeds.js
+++ b/api/prisma/seeds.js
@@ -1,0 +1,49 @@
+/* eslint-disable no-console */
+const { PrismaClient } = require('@prisma/client')
+const db = new PrismaClient()
+
+const DEFAULT_INVOICE = {
+  title: 'I N V O I C E',
+  companyName: 'Example Inc.',
+  companyInfo: 'example.com\ninfo@example.com',
+  recipient:
+    'Michael Scott Paper Company Inc.\n1725 Slough Avenue\nScranton, Pennsylvania',
+  information: [
+    [{ value: 'Invoice #' }, { value: '044' }],
+    [
+      { value: 'Date' },
+      { value: new Intl.DateTimeFormat().format(new Date()) },
+    ],
+  ],
+  lineItems: [
+    [{ value: 'Description' }, { value: 'Quantity' }, { value: 'Price' }],
+    [{ value: 'Wheel of cheese' }, { value: 1 }, { value: 500 }],
+    [{ value: 'Jar of sausages' }, { value: 2 }, { value: 2.99 }],
+    [{ value: 'Tin of waffles' }, { value: 2 }, { value: 3.01 }],
+  ],
+  summary: [
+    [{ value: 'Subtotal' }, undefined, '0.0'],
+    [{ value: 'Tax Rate' }, { value: 0 }, '0.0'],
+    [{ value: 'Total' }, { value: '$' }, '0.0'],
+  ],
+  notesA: '',
+  notesB: 'Invoice by billable.me',
+}
+
+async function main() {
+  const invoiceOne = await db.invoice.findOne({ where: { id: 1 } });
+  if (!invoiceOne) {
+    const invoice = await db.invoice.create({ data: {
+      invoiceNumber: '2020001',
+      date: '03/12/2020',
+      body: JSON.stringify(DEFAULT_INVOICE)
+    }})
+    console.log(`Added example invoice with id=${invoice.id}`)
+  }
+}
+
+main()
+  .catch((e) => console.error(e))
+  .finally(async () => {
+    await db.disconnect()
+  })

--- a/web/src/components/InvoiceEditor/InvoiceEditor.js
+++ b/web/src/components/InvoiceEditor/InvoiceEditor.js
@@ -6,7 +6,7 @@ import Summary from 'src/components/Summary'
 
 const MARGIN_BOTTOM = 4
 
-export default ({ invoice = DEFAULT_INVOICE, setInvoice }) => {
+export default ({ invoice, setInvoice }) => {
   const {
     title,
     companyName,
@@ -101,32 +101,4 @@ export default ({ invoice = DEFAULT_INVOICE, setInvoice }) => {
       </Flex>
     </>
   )
-}
-
-const DEFAULT_INVOICE = {
-  title: 'I N V O I C E',
-  companyName: 'Example Inc.',
-  companyInfo: 'example.com\ninfo@example.com',
-  recipient:
-    'Michael Scott Paper Company Inc.\n1725 Slough Avenue\nScranton, Pennsylvania',
-  information: [
-    [{ value: 'Invoice #' }, { value: '044' }],
-    [
-      { value: 'Date' },
-      { value: new Intl.DateTimeFormat().format(new Date()) },
-    ],
-  ],
-  lineItems: [
-    [{ value: 'Description' }, { value: 'Quantity' }, { value: 'Price' }],
-    [{ value: 'Wheel of cheese' }, { value: 1 }, { value: 500 }],
-    [{ value: 'Jar of sausages' }, { value: 2 }, { value: 2.99 }],
-    [{ value: 'Tin of waffles' }, { value: 2 }, { value: 3.01 }],
-  ],
-  summary: [
-    [{ value: 'Subtotal' }, undefined, '0.0'],
-    [{ value: 'Tax Rate' }, { value: 0 }, '0.0'],
-    [{ value: 'Total' }, { value: '$' }, '0.0'],
-  ],
-  notesA: '',
-  notesB: 'Invoice by billable.me',
 }


### PR DESCRIPTION
While exploring RedwoodJS, I wanted to get the `example-invoice` running on my machine. After a bit of struggling and exploration, I've got it working by moving the seed data from the  `InvoiceEditor` component into the seeds file (which was missing). I've updated the README accordingly. 

Hope this helps! 